### PR TITLE
Gateway As Password Vault sample policy

### DIFF
--- a/Gateway-As-Password-Vault/README.md
+++ b/Gateway-As-Password-Vault/README.md
@@ -1,0 +1,37 @@
+# Gateway As Password Vault
+This policy sets up a simple password vault on the Gateway that accesses encrypted passwords stored in the Secure Password Store on the Gateway. It can be used by the manage_binlogs.sh and audit_purge.sh scripts that both mention using a service on the Gateway to provide the passwords used by the scripts in lieu of hardcoding them, or by other local scripts as required.
+
+It requires each password to be set up in the 'Tasks -> Certificates, Keys and Secrets -> Manage Stored Passwords' with the 'Permit use via context variable reference' box checked. That checkbox means that policies can obtain the plaintext of a password that is encrypted in the database by referencing the ${secpass.&lt;pwdname&gt;.plaintext} context variable.
+
+In the manage_binlogs.sh and audit_purge.sh scripts there are lines for setting DBPWD and ROOTDBPWD that are normally hard coded but that can call wget (or curl) to obtain the password at runtime, so we publish a Web API type endpoint at /getPwd on the Gateway to do this. Since this endpoint is delivering the password in the clear we need to set up security on it, and IMO checking that the call is over SSL and from localhost is the minimum and, in most cases, is strong enough. Beyond that it becomes a lesson in security through obscurity, since some passphrase is going to be required to unlock further security to make the call, and if that is the case then you might as well just put the passwords you are trying to get in whatever vault you use to get the password from the service.
+
+Did that make sense? :) To be honest, if you have an existing password vault that can be called from a shell script I recommend using that, since it has probably already been cleared by your security team.
+
+# Risks
+The following risks need to be considered:
+
+  - If someone gains access to the Gateway using the Policy Manager or Restman they can publish their own service to simply return the password without any security on it
+  - If someone gains root access to the OS they can just call the service directly from localhost to get the password in the clear
+
+In both cases there has already been a pretty major security breach, so it depends on your security requirements as to whether that level of risk is acceptable. The advantage is that the passwords are never stored in the clear.
+
+# Deployment
+- Set up the passwords to be delivered in the 'Task -> Certificates, Keys and Secrets -> Manage Stored Passwords' interface, ensuring that the 'Permit use via context variable reference' box is checked for each.
+- Publish a service at /getPwd and load the getPwd.xml policy into it.
+- Modify the policy to match the passwords that can be delivered by the service. Note that each password will need its own block in the *// Retrieve password for name set in ${request.http/parameter.p}* block. The names MUST match the names set in the 'Tasks -> Certificates, Keys and Secrets -> Manage Stored Passwords' step above.
+
+# Testing
+You can use curl or wget the test the service:
+
+    # curl -k https://localhost:8443/getPwd?p=dbreplpwd
+    # wget -O- -q --no-check-certificate https://localhost:8443d?p=dbreplpwd
+
+The following test should succeed:
+
+- Call https://localhost:8443/getPwd?p=&lt;password&gt; where &lt;password&gt; matches a password set up in the policy
+
+The following tests should result in a closed connection:
+
+- Call from a non-localhost IP addresses
+- Call from localhost and remote IP address to non-ssl endpoint (port 8080)
+- Call with a password not recognised by the policy

--- a/Gateway-As-Password-Vault/getPwd.xml
+++ b/Gateway-As-Password-Vault/getPwd.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<exp:Export Version="3.0"
+    xmlns:L7p="http://www.layer7tech.com/ws/policy"
+    xmlns:exp="http://www.layer7tech.com/ws/policy/export" xmlns:wsp="http://schemas.xmlsoap.org/ws/2002/12/policy">
+    <exp:References/>
+    <wsp:Policy xmlns:L7p="http://www.layer7tech.com/ws/policy" xmlns:wsp="http://schemas.xmlsoap.org/ws/2002/12/policy">
+        <wsp:All wsp:Usage="Required">
+            <L7p:CommentAssertion>
+                <L7p:Comment stringValue="***********************************************************************************************************"/>
+            </L7p:CommentAssertion>
+            <L7p:CommentAssertion>
+                <L7p:Comment stringValue="* Policy to retrieve password from the secure password store and return in response"/>
+            </L7p:CommentAssertion>
+            <L7p:CommentAssertion>
+                <L7p:Comment stringValue="* "/>
+            </L7p:CommentAssertion>
+            <L7p:CommentAssertion>
+                <L7p:Comment stringValue="* Fails with a closed connection on the following conditions:"/>
+            </L7p:CommentAssertion>
+            <L7p:CommentAssertion>
+                <L7p:Comment stringValue="*   - Request not made over SSL"/>
+            </L7p:CommentAssertion>
+            <L7p:CommentAssertion>
+                <L7p:Comment stringValue="*   - Request not from localhost"/>
+            </L7p:CommentAssertion>
+            <L7p:CommentAssertion>
+                <L7p:Comment stringValue="*   - Request password is not found in the Stored Passwords"/>
+            </L7p:CommentAssertion>
+            <L7p:CommentAssertion>
+                <L7p:Comment stringValue="* "/>
+            </L7p:CommentAssertion>
+            <L7p:CommentAssertion>
+                <L7p:Comment stringValue="* Jay MacDonald - 20220425"/>
+            </L7p:CommentAssertion>
+            <L7p:CommentAssertion>
+                <L7p:Comment stringValue="***********************************************************************************************************"/>
+            </L7p:CommentAssertion>
+            <L7p:CustomizeErrorResponse>
+                <L7p:AssertionComment assertionComment="included">
+                    <L7p:Properties mapValue="included">
+                        <L7p:entry>
+                            <L7p:key stringValue="RIGHT.COMMENT"/>
+                            <L7p:value stringValue="// Drop connection on failure - no error responses"/>
+                        </L7p:entry>
+                    </L7p:Properties>
+                </L7p:AssertionComment>
+                <L7p:ErrorLevel errorLevel="DROP_CONNECTION"/>
+                <L7p:ExtraHeaders nameValuePairArray="included"/>
+            </L7p:CustomizeErrorResponse>
+            <L7p:SslAssertion>
+                <L7p:AssertionComment assertionComment="included">
+                    <L7p:Properties mapValue="included">
+                        <L7p:entry>
+                            <L7p:key stringValue="RIGHT.COMMENT"/>
+                            <L7p:value stringValue="// Request MUST be over SSL"/>
+                        </L7p:entry>
+                    </L7p:Properties>
+                </L7p:AssertionComment>
+            </L7p:SslAssertion>
+            <wsp:OneOrMore wsp:Usage="Required">
+                <L7p:RemoteIpAddressRange>
+                    <L7p:AssertionComment assertionComment="included">
+                        <L7p:Properties mapValue="included">
+                            <L7p:entry>
+                                <L7p:key stringValue="RIGHT.COMMENT"/>
+                                <L7p:value stringValue="// ipv6"/>
+                            </L7p:entry>
+                        </L7p:Properties>
+                    </L7p:AssertionComment>
+                    <L7p:NetworkMask stringValue="128"/>
+                    <L7p:StartIp stringValue="::1"/>
+                </L7p:RemoteIpAddressRange>
+                <L7p:RemoteIpAddressRange>
+                    <L7p:AssertionComment assertionComment="included">
+                        <L7p:Properties mapValue="included">
+                            <L7p:entry>
+                                <L7p:key stringValue="RIGHT.COMMENT"/>
+                                <L7p:value stringValue="// ipv4"/>
+                            </L7p:entry>
+                        </L7p:Properties>
+                    </L7p:AssertionComment>
+                    <L7p:NetworkMask stringValue="8"/>
+                    <L7p:StartIp stringValue="127.0.0.0"/>
+                </L7p:RemoteIpAddressRange>
+                <L7p:assertionComment>
+                    <L7p:Properties mapValue="included">
+                        <L7p:entry>
+                            <L7p:key stringValue="RIGHT.COMMENT"/>
+                            <L7p:value stringValue="// Limit to localhost access"/>
+                        </L7p:entry>
+                    </L7p:Properties>
+                </L7p:assertionComment>
+            </wsp:OneOrMore>
+            <wsp:OneOrMore wsp:Usage="Required">
+                <wsp:All wsp:Usage="Required">
+                    <L7p:ComparisonAssertion>
+                        <L7p:CaseSensitive booleanValue="false"/>
+                        <L7p:Expression1 stringValue="${request.http.parameter.p}"/>
+                        <L7p:Operator operatorNull="null"/>
+                        <L7p:Predicates predicates="included">
+                            <L7p:item dataType="included">
+                                <L7p:Type variableDataType="string"/>
+                            </L7p:item>
+                            <L7p:item binary="included">
+                                <L7p:RightValue stringValue="dbadminpwd"/>
+                            </L7p:item>
+                        </L7p:Predicates>
+                    </L7p:ComparisonAssertion>
+                    <L7p:SetVariable>
+                        <L7p:Base64Expression stringValue="JHtzZWNwYXNzLmRiYWRtaW5wd2QucGxhaW50ZXh0fQ=="/>
+                        <L7p:VariableToSet stringValue="pwd"/>
+                    </L7p:SetVariable>
+                    <L7p:assertionComment>
+                        <L7p:Properties mapValue="included">
+                            <L7p:entry>
+                                <L7p:key stringValue="RIGHT.COMMENT"/>
+                                <L7p:value stringValue="// ${request.http.parameter.p} == 'dbadminpwd'"/>
+                            </L7p:entry>
+                        </L7p:Properties>
+                    </L7p:assertionComment>
+                </wsp:All>
+                <wsp:All wsp:Usage="Required">
+                    <L7p:ComparisonAssertion>
+                        <L7p:CaseSensitive booleanValue="false"/>
+                        <L7p:Expression1 stringValue="${request.http.parameter.p}"/>
+                        <L7p:Operator operatorNull="null"/>
+                        <L7p:Predicates predicates="included">
+                            <L7p:item dataType="included">
+                                <L7p:Type variableDataType="string"/>
+                            </L7p:item>
+                            <L7p:item binary="included">
+                                <L7p:RightValue stringValue="dbreplpwd"/>
+                            </L7p:item>
+                        </L7p:Predicates>
+                    </L7p:ComparisonAssertion>
+                    <L7p:SetVariable>
+                        <L7p:Base64Expression stringValue="JHtzZWNwYXNzLmRicmVwbHB3ZC5wbGFpbnRleHR9"/>
+                        <L7p:VariableToSet stringValue="pwd"/>
+                    </L7p:SetVariable>
+                    <L7p:assertionComment>
+                        <L7p:Properties mapValue="included">
+                            <L7p:entry>
+                                <L7p:key stringValue="RIGHT.COMMENT"/>
+                                <L7p:value stringValue="// ${request.http.parameter.p} == 'dbreplpwd'"/>
+                            </L7p:entry>
+                        </L7p:Properties>
+                    </L7p:assertionComment>
+                </wsp:All>
+                <L7p:assertionComment>
+                    <L7p:Properties mapValue="included">
+                        <L7p:entry>
+                            <L7p:key stringValue="RIGHT.COMMENT"/>
+                            <L7p:value stringValue="// Retrieve password for name set in ${request.http.parameter.p}, fail if not found"/>
+                        </L7p:entry>
+                    </L7p:Properties>
+                </L7p:assertionComment>
+            </wsp:OneOrMore>
+            <L7p:HardcodedResponse>
+                <L7p:AssertionComment assertionComment="included">
+                    <L7p:Properties mapValue="included">
+                        <L7p:entry>
+                            <L7p:key stringValue="RIGHT.COMMENT"/>
+                            <L7p:value stringValue="// 200 text/plain"/>
+                        </L7p:entry>
+                    </L7p:Properties>
+                </L7p:AssertionComment>
+                <L7p:Base64ResponseBody stringValue="JHtwd2R9"/>
+                <L7p:ResponseContentType stringValue="text/plain; charset=UTF-8"/>
+            </L7p:HardcodedResponse>
+        </wsp:All>
+    </wsp:Policy>
+</exp:Export>

--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@ This repository is for more general policy examples that are typically self-cont
 |Name|Brief Description|
 |-----|-----------------|
 |[**sample**](./policy)|This is a sample policy containing a single comment as used to provide an example of how policies should be described and stored in this repository.|
-|[**Restman Policy**](./Restman-Policy)|A replacement policy for the default Gateway REST Management Service that has better documentation, error handling and inline comments.|
-|[**JWK Grok**](./JWK-Grok)|JWK-Grok is a set of two API Gateway services to help understand how the JOSE features of the API Gateway work.|
-|[**Conditional Auditing**](./Conditional-Auditing)|Enable auditing for specific services via a cluster-wide property|
-|[**Log4Shell**](./log4shell)|Simple filter that looks for a pattern which may be indicative of a log4shell exploit.|
-|[**GraphQL Patterns Today**](./graphqlToday)|Proxying GraphQL API in Layer7 Policy prior to new GraphQL assertions|
 |[**Cluster Wide Property Manager**](./Cluster-wide-property-manager)|This uses the REST Manage Gateway assertion to provide a simple web page interface to create, update and delete cluster wide properties|
-|[**Trusted Certificate Viewer**](./trusted-certs-viewer)|This polcy uses the  REST Manage Gateway assertion to provide a simple web page interface to view all the trusted certificates and the expiry date|
+|[**Conditional Auditing**](./Conditional-Auditing)|Enable auditing for specific services via a cluster-wide property|
 |[**Expired Certificate Notifcation Service (email)**](./expired-cert-email-notifier)|This sample policy uses the REST Manage Gateway assertion to provide a simple notification service for any trusted certificates that are on the gateway. The service sends emails for any certificates it finds to have expired.|
+|[**Gateway As Password Vault**](./Gateway-As-Password-Vault)|Policy to set up a simple password vault on the Gateway that accesses encrypted passwords stored in the Secure Password Store on the Gateway.|
+|[**GraphQL Patterns Today**](./graphqlToday)|Proxying GraphQL API in Layer7 Policy prior to new GraphQL assertions|
+|[**JWK Grok**](./JWK-Grok)|JWK-Grok is a set of two API Gateway services to help understand how the JOSE features of the API Gateway work.|
 |[**JWT Parsing Demo**](./JWT-Parsing-Demo)|A simple policy to demonstrate how to parse an unsigned JWT|
+|[**Log4Shell**](./log4shell)|Simple filter that looks for a pattern which may be indicative of a log4shell exploit.|
+|[**Restman Policy**](./Restman-Policy)|A replacement policy for the default Gateway REST Management Service that has better documentation, error handling and inline comments.|
+|[**Trusted Certificate Viewer**](./trusted-certs-viewer)|This polcy uses the  REST Manage Gateway assertion to provide a simple web page interface to view all the trusted certificates and the expiry date|
 
 
 ## Using the Repository


### PR DESCRIPTION
- Updated README.md with a minor fix (testing github)
- Added JWK-Grok and updated main README.md
- New policy log4shell scan
- moved to its own subfolder
- Update README.md
- Initial release of Gateway REST Management Service policy (20220111)
- added graphql proxy sample policy
- Create Readme.md
- Add files via upload
- Update README.md
- Update README.md
- Create readme.md
- Add files via upload
- Update README.md
- Update readme.md
- Update readme.md
- Update README.md
- Create readme.md
- Add files via upload
- Update README.md
- Initial version uploaded
- Added JWT Parsing Demo sample policy
- Added Gateway As Password Vault sample and alphabetically sorted the sample policies table in the main README.md file
